### PR TITLE
fix: handle 404 orderbook gracefully with better error messages (#38)

### DIFF
--- a/backend/src/main/kotlin/com/wrbug/polymarketbot/service/common/MarketPriceService.kt
+++ b/backend/src/main/kotlin/com/wrbug/polymarketbot/service/common/MarketPriceService.kt
@@ -250,6 +250,12 @@ class MarketPriceService(
             
             val orderbookResponse = clobApi.getOrderbook(tokenId = tokenId, market = null)
             
+            // 404 表示订单簿不存在，返回 null 以触发 Gamma API 降级
+            if (orderbookResponse.code() == 404) {
+                logger.debug("CLOB 订单簿不存在（404）: tokenId=$tokenId，降级到 Gamma API")
+                return null
+            }
+            
             if (!orderbookResponse.isSuccessful || orderbookResponse.body() == null) {
                 return null
             }

--- a/backend/src/main/kotlin/com/wrbug/polymarketbot/service/common/PolymarketClobService.kt
+++ b/backend/src/main/kotlin/com/wrbug/polymarketbot/service/common/PolymarketClobService.kt
@@ -28,6 +28,10 @@ class PolymarketClobService(
             val response = clobApi.getOrderbook(tokenId = null, market = market)
             if (response.isSuccessful && response.body() != null) {
                 Result.success(response.body()!!)
+            } else if (response.code() == 404) {
+                // 404 表示市场不存在或订单簿为空（如新上市市场、即将结算的市场），返回空结果而非错误
+                logger.debug("订单簿不存在（404）: market=$market")
+                Result.success(OrderbookResponse(bids = emptyList(), asks = emptyList()))
             } else {
                 Result.failure(Exception("获取订单簿失败: ${response.code()} ${response.message()}"))
             }
@@ -46,6 +50,10 @@ class PolymarketClobService(
             val response = clobApi.getOrderbook(tokenId = tokenId, market = null)
             if (response.isSuccessful && response.body() != null) {
                 Result.success(response.body()!!)
+            } else if (response.code() == 404) {
+                // 404 表示该 token 的订单簿不存在（如新上市市场、即将结算的市场），返回空结果而非错误
+                logger.debug("订单簿不存在（404）: tokenId=$tokenId")
+                Result.success(OrderbookResponse(bids = emptyList(), asks = emptyList()))
             } else {
                 Result.failure(Exception("获取订单簿失败: ${response.code()} ${response.message()}"))
             }
@@ -142,8 +150,9 @@ class PolymarketClobService(
             // 市价卖单：需要 bestBid（最高买入价）
             val bestBid = orderbook.bids.firstOrNull()?.price
             if (bestBid == null) {
-                val errorMsg = "订单表 bids 为空: tokenId=$tokenId"
-                logger.error(errorMsg)
+                // 订单簿为空，返回更友好的错误信息
+                val errorMsg = "当前市场暂时无法卖出（订单簿为空），请尝试使用限价单"
+                logger.warn("市价卖单订单簿为空: tokenId=$tokenId")
                 throw IllegalStateException(errorMsg)
             }
             
@@ -166,8 +175,9 @@ class PolymarketClobService(
             // 市价买单：需要 bestAsk（最低卖出价）
             val bestAsk = orderbook.asks.firstOrNull()?.price
             if (bestAsk == null) {
-                val errorMsg = "订单表 asks 为空: tokenId=$tokenId"
-                logger.error(errorMsg)
+                // 订单簿为空，返回更友好的错误信息
+                val errorMsg = "当前市场暂时无法买入（订单簿为空），请尝试使用限价单"
+                logger.warn("市价买单订单簿为空: tokenId=$tokenId")
                 throw IllegalStateException(errorMsg)
             }
             


### PR DESCRIPTION
## Issue
无法卖出仓位 - 市价单显示订单簿 404，限价单也提示 order book 有问题

## Root Cause
Polymarket CLOB API returns 404 when orderbook does not exist (new markets, markets being settled). Previous code treated 404 as an error.

## Fix
1. **PolymarketClobService.getOrderbook() / getOrderbookByTokenId()**: Return empty orderbook on 404 instead of failure, enabling graceful fallback
2. **getOptimalPrice()**: Better error message - from "orderbook bids empty" to "market cannot sell right now (orderbook empty), please try limit order"
3. **MarketPriceService.getPriceFromClobOrderbook()**: Return null on 404 to trigger Gamma API fallback

## Effect
- No more 404 error when orderbook does not exist
- Market orders show user-friendly message to use limit orders
- Gamma API provides price fallback

## Files Changed
- backend/.../PolymarketClobService.kt - handle 404 as empty orderbook
- backend/.../MarketPriceService.kt - handle 404 for Gamma fallback