### PR TITLE
fix: #38 无法卖出仓位 - 订单簿404回退与Neg Risk支持

### DIFF
--- a/backend/src/main/kotlin/com/wrbug/polymarketbot/service/accounts/AccountService.kt
+++ b/backend/src/main/kotlin/com/wrbug/polymarketbot/service/accounts/AccountService.kt
@@ -15,8 +15,10 @@ import com.wrbug.polymarketbot.util.getEventSlug
 import com.google.gson.JsonObject
 import com.google.gson.JsonPrimitive
 import com.wrbug.polymarketbot.service.common.PolymarketClobService
+import com.wrbug.polymarketbot.service.common.OrderbookNotFoundException
 import com.wrbug.polymarketbot.service.common.BlockchainService
 import com.wrbug.polymarketbot.service.common.MarketService
+import com.wrbug.polymarketbot.service.common.MarketPriceService
 import com.wrbug.polymarketbot.service.common.PolymarketApiKeyService
 import com.wrbug.polymarketbot.service.copytrading.orders.OrderPushService
 import com.wrbug.polymarketbot.service.copytrading.orders.OrderSigningService
@@ -44,6 +46,7 @@ class AccountService(
     private val orderSigningService: OrderSigningService,
     private val cryptoUtils: CryptoUtils,
     private val marketService: MarketService,  // 市场信息服务
+    private val marketPriceService: MarketPriceService,  // 市场价格服务（用于订单簿回退）
     private val telegramNotificationService: TelegramNotificationService? = null,  // 可选，避免循环依赖
     private val relayClientService: RelayClientService,
     private val jsonUtils: JsonUtils
@@ -1211,15 +1214,32 @@ class AccountService(
             // - 市价买单：从订单表获取 bestAsk（最低卖出价），然后加上 BUY_PRICE_ADJUSTMENT
             // 限价订单：使用用户输入的价格
             // 注意：使用 outcomeIndex 和 tokenId 支持多元市场（二元、三元及以上）
-            // 如果无法获取订单表，将抛出异常
+            // 如果无法获取订单表，尝试从市场价格回退
             val sellPrice = if (request.orderType == "MARKET") {
                 try {
                     // 市价单：从订单表获取最优价（卖出订单，需要 bestBid）
                     // 通过 tokenId 获取对应 outcome 的订单表，支持多元市场
                     getOptimalPriceFromOrderbook(tokenId, isSellOrder = true)
                 } catch (e: IllegalStateException) {
-                    logger.error("无法获取订单表最优价: ${e.message}", e)
-                    return Result.failure(IllegalStateException("无法获取订单表最优价: ${e.message}"))
+                    if (e.cause is OrderbookNotFoundException) {
+                        // 订单簿不存在（404），尝试从市场价格获取作为回退
+                        logger.warn("订单簿不存在，尝试从市场价格回退: tokenId=$tokenId, marketId=${request.marketId}")
+                        val fallbackPrice = try {
+                            marketPriceService.getCurrentMarketPrice(request.marketId, request.outcomeIndex ?: 0)
+                        } catch (ex: Exception) {
+                            logger.error("回退到市场价格也失败: ${ex.message}", ex)
+                            return Result.failure(IllegalStateException("无法获取卖出价格：订单簿不存在且市场价格获取失败 (${e.message})"))
+                        }
+                        if (fallbackPrice <= BigDecimal.ZERO || fallbackPrice > BigDecimal("0.99")) {
+                            return Result.failure(IllegalStateException("无法获取有效的卖出价格：回退价格异常 ($fallbackPrice)"))
+                        }
+                        // 回退价格使用更激进的调整（减 0.03），确保市价单能快速成交
+                        val adjustedFallback = fallbackPrice.subtract(BigDecimal("0.03"))
+                        adjustedFallback.coerceAtLeast(BigDecimal("0.01")).coerceAtMost(BigDecimal("0.99")).toPlainString()
+                    } else {
+                        logger.error("无法获取订单表最优价: ${e.message}", e)
+                        return Result.failure(IllegalStateException("无法获取订单表最优价: ${e.message}"))
+                    }
                 }
             } else {
                 // 限价订单：使用用户输入的价格
@@ -1251,6 +1271,15 @@ class AccountService(
             // 7. 解密私钥
             val decryptedPrivateKey = decryptPrivateKey(account)
 
+            // 检查是否为 Neg Risk 市场，使用对应的 Exchange 合约签名
+            val negRisk = marketService.getNegRiskByConditionId(request.marketId) == true
+            val exchangeContract = if (negRisk) {
+                logger.info("Neg Risk 市场，使用 Neg Risk Exchange 签名: marketId=${request.marketId}")
+                orderSigningService.getExchangeContract(negRisk = true)
+            } else {
+                null
+            }
+
             // 获取费率（根据 Polymarket Maker Rebates Program 要求）
             val feeRateResult = clobService.getFeeRate(tokenId)
             val feeRateBps = if (feeRateResult.isSuccess) {
@@ -1272,7 +1301,8 @@ class AccountService(
                     signatureType = orderSigningService.getSignatureTypeForWalletType(account.walletType),
                     nonce = "0",
                     feeRateBps = feeRateBps,  // 使用动态获取的费率
-                    expiration = expiration
+                    expiration = expiration,
+                    exchangeContract = exchangeContract  // Neg Risk 市场使用对应的 Exchange 合约
                 )
             } catch (e: Exception) {
                 logger.error("创建并签名订单失败", e)

--- a/backend/src/main/kotlin/com/wrbug/polymarketbot/service/common/PolymarketClobService.kt
+++ b/backend/src/main/kotlin/com/wrbug/polymarketbot/service/common/PolymarketClobService.kt
@@ -8,6 +8,12 @@ import org.springframework.stereotype.Service
 import java.math.BigDecimal
 
 /**
+ * 订单簿不存在的异常（HTTP 404）
+ * 表示该 token 没有活跃的订单簿，不是致命错误，调用方可以决定回退策略
+ */
+class OrderbookNotFoundException(message: String) : Exception(message)
+
+/**
  * Polymarket CLOB API 服务封装
  * 提供订单操作、市场数据、交易数据等功能
  */
@@ -46,6 +52,11 @@ class PolymarketClobService(
             val response = clobApi.getOrderbook(tokenId = tokenId, market = null)
             if (response.isSuccessful && response.body() != null) {
                 Result.success(response.body()!!)
+            } else if (response.code() == 404) {
+                // 404 表示该 token 没有活跃的订单簿（可能是流动性不足或市场已结算）
+                // 这不是致命错误，调用方可以决定是否需要回退
+                logger.warn("订单簿不存在 (404): tokenId=$tokenId")
+                Result.failure(OrderbookNotFoundException("订单簿不存在: tokenId=$tokenId"))
             } else {
                 Result.failure(Exception("获取订单簿失败: ${response.code()} ${response.message()}"))
             }
@@ -128,7 +139,7 @@ class PolymarketClobService(
             val error = orderbookResult.exceptionOrNull()
             val errorMsg = "获取订单表失败: ${error?.message ?: "未知错误"}"
             logger.error(errorMsg)
-            throw IllegalStateException(errorMsg)
+            throw IllegalStateException(errorMsg, error)
         }
         
         val orderbook = orderbookResult.getOrNull()


### PR DESCRIPTION
## 问题描述
无法卖出仓位：市价单显示订单簿 404，限价单也提示 order book 有问题。

## 根因分析
1. **订单簿 404 无回退**：当 Polymarket CLOB API 返回 404（订单簿不存在，如流动性不足或市场已结算）时，市价单直接失败，没有回退策略
2. **Neg Risk 市场签名错误**：卖出流程未检测 Neg Risk 市场，导致使用错误的 Exchange 合约签名，订单创建失败
3. **异常链丢失**：`getOptimalPrice` 抛出 `IllegalStateException` 时未保留原始异常作为 cause

## 修复内容
- **PolymarketClobService**: 新增 `OrderbookNotFoundException` 区分 404 与其他错误
- **PolymarketClobService.getOptimalPrice**: 保留异常链以便调用方判断错误类型
- **AccountService.sellPosition**: 市价单订单簿 404 时回退到 `MarketPriceService` 获取价格
- **AccountService.sellPosition**: 支持 Neg Risk 市场，使用正确的 Exchange 合约签名

## 测试
- ✅ Backend 编译通过 (`compileKotlin`)

Fixes #38