### PR TITLE
fix: handle neg_risk market in sellPosition

### DIFF
--- a/backend/src/main/kotlin/com/wrbug/polymarketbot/service/accounts/AccountService.kt
+++ b/backend/src/main/kotlin/com/wrbug/polymarketbot/service/accounts/AccountService.kt
@@ -1247,7 +1247,14 @@ class AccountService(
             // 7. 解密私钥
             val decryptedPrivateKey = decryptPrivateKey(account)
 
-            // 11. 创建并签名订单（使用计算后的卖出数量，按账户钱包类型使用对应 signatureType）
+            // 11. 检查市场是否为 Neg Risk 市场，获取正确的 Exchange 合约地址
+            val negRisk = marketService.getNegRiskByConditionId(request.marketId) == true
+            val exchangeContract = orderSigningService.getExchangeContract(negRisk)
+            if (negRisk) {
+                logger.debug("市场为 Neg Risk，使用 Neg Risk Exchange 签约: conditionId=${request.marketId}")
+            }
+
+            // 12. 创建并签名订单（使用计算后的卖出数量，按账户钱包类型使用对应 signatureType）
             val signedOrder = try {
                 orderSigningService.createAndSignOrder(
                     privateKey = decryptedPrivateKey,
@@ -1256,14 +1263,15 @@ class AccountService(
                     side = "SELL",
                     price = sellPrice,
                     size = sellQuantity.toPlainString(),  // 使用计算后的卖出数量
-                    signatureType = orderSigningService.getSignatureTypeForWalletType(account.walletType)
+                    signatureType = orderSigningService.getSignatureTypeForWalletType(account.walletType),
+                    exchangeContract = exchangeContract
                 )
             } catch (e: Exception) {
                 logger.error("创建并签名订单失败", e)
                 return Result.failure(Exception("创建并签名订单失败: ${e.message}"))
             }
 
-            // 12. 构建订单请求
+            // 13. 构建订单请求
 
             val newOrderRequest = com.wrbug.polymarketbot.api.NewOrderRequest(
                 order = signedOrder,


### PR DESCRIPTION
## Summary

Fixes #38 - 无法卖出仓位

The `sellPosition` method in `AccountService` was not checking whether the market uses the Neg Risk Exchange contract. For neg_risk markets, the order must be signed with the Neg Risk Exchange address (`0xe2222d279d744050d28e00520010520000310F59`) instead of the standard CTF Exchange (`0xE111180000d2663C0091e4f400237545B87B996B`). Otherwise, Polymarket rejects the order.

The copy trading service (`CopyOrderTrackingService`) already handles this correctly, but the manual sell position flow was missing this check.

## Changes

- **AccountService.sellPosition**: Added neg_risk detection via `marketService.getNegRiskByConditionId()` and passes the correct `exchangeContract` to `orderSigningService.createAndSignOrder()`

## Testing

- Verified that `MarketService.getNegRiskByConditionId()` is already available and used in other parts of `AccountService` (redeem flow)
- Verified that `OrderSigningService.createAndSignOrder()` already accepts an optional `exchangeContract` parameter
- Followed the same pattern used in `CopyOrderTrackingService` lines 568-570

Fixes #38